### PR TITLE
Handle Plex search timeouts

### DIFF
--- a/plex_index.py
+++ b/plex_index.py
@@ -279,7 +279,7 @@ def plex_search_guids(query: str) -> Iterator[TypedRatingKey]:
             for m in re.findall(GUID_RE, data):
                 yield typed_rating_key(*m)
             return
-        except urllib.error.URLError as e:
+        except (TimeoutError, urllib.error.URLError) as e:
             if attempt == 2:
                 logger.warning("search failed for %s: %s", query, e)
                 return


### PR DESCRIPTION
## Summary
- treat TimeoutError as a transient failure when searching Plex, allowing retries

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68de1cc0a2d88326bb04dd0f65115b21